### PR TITLE
Bugfix/improved error reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .vs/
 dxc_test_main.dir/
 x64/
+Debug/
 
 # CMake
 CMakeCache.txt

--- a/data/shaders/testCompilatonError.hlsl
+++ b/data/shaders/testCompilatonError.hlsl
@@ -1,0 +1,17 @@
+//This code should generate compilation errors. Errors should be readable.
+//
+//UTF8 test (random UTF-8 chars):
+//     ŠןɉъҹĦİ·̈ȥ۳ٴ̻ؽ̊ܚ
+//     ʳϛƥȀۤҿ͔Ԝ҂ɝŨױʠɊ݉ܐ
+//     ÌàۂɕӬҗѪ̹߮פڹړȾݒĸê
+//     ǿ׋ق˿ɴ°ڥ׬щߖ΢Ùסȼ݅
+//     ˗ΖɊΧ٭ϟڴޒ¢̇źʟǔ׍ը
+//     ɕݫÞшǈ߳ȁىЇÌֶӔ͞ÓƿŇ
+//     ߆ߺӰֱ̇ɷĜܴŦͼǃǒƀ̽ű
+//     ɅʞܒЌ˴̯ۇ̡ƽׅʮù߅ԩ˸
+[numthreads(8, 8, 8)] void main(uint3 global_i : SV_DispatchThreadID) {
+    float4 vTest = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
+    float4 v2 = v1;
+    float4 vTest2 = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
+    float4 v4 = v3;
+}

--- a/data/shaders/testCompilatonSuccess.hlsl
+++ b/data/shaders/testCompilatonSuccess.hlsl
@@ -1,0 +1,14 @@
+//this code should compile
+//
+//UTF8 test (random UTF-8 chars):
+//     ŠןɉъҹĦİ·̈ȥ۳ٴ̻ؽ̊ܚ
+//     ʳϛƥȀۤҿ͔Ԝ҂ɝŨױʠɊ݉ܐ
+//     ÌàۂɕӬҗѪ̹߮פڹړȾݒĸê
+//     ǿ׋ق˿ɴ°ڥ׬щߖ΢Ùסȼ݅
+//     ˗ΖɊΧ٭ϟڴޒ¢̇źʟǔ׍ը
+//     ɕݫÞшǈ߳ȁىЇÌֶӔ͞ÓƿŇ
+//     ߆ߺӰֱ̇ɷĜܴŦͼǃǒƀ̽ű
+//     ɅʞܒЌ˴̯ۇ̡ƽׅʮù߅ԩ˸
+[numthreads(8, 8, 8)] void main(uint3 global_i : SV_DispatchThreadID) {
+    float4 vTest = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
+}

--- a/data/shaders/testUTF8.hlsl
+++ b/data/shaders/testUTF8.hlsl
@@ -1,0 +1,8 @@
+//patate éà
+[numthreads(8, 8, 8)] void main(uint3 global_i : SV_DispatchThreadID) {
+	// add code here
+	float4 vTest = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
+    float4 v2 = v1;
+    float4 vTest2 = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
+    float4 v4 = v3;
+}

--- a/data/shaders/testUTF8.hlsl
+++ b/data/shaders/testUTF8.hlsl
@@ -1,8 +1,0 @@
-//patate éà
-[numthreads(8, 8, 8)] void main(uint3 global_i : SV_DispatchThreadID) {
-	// add code here
-	float4 vTest = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
-    float4 v2 = v1;
-    float4 vTest2 = float4((float)global_i.x, (float)global_i.y, (float)global_i.z, 0);
-    float4 v4 = v3;
-}


### PR DESCRIPTION
Add tests hlsl files to test both successful compilation and error reporting.

At this point, the program outputs the following text in the console:
```
Test 1 : This one should compile

spv:
0000000007230203 0000000000010300 00000000000E0000 0000000000000009 0000000000000000 0000000000020011 0000000000000001 000000000003000E
0000000000000000 0000000000000001 000000000006000F 0000000000000005 0000000000000001 000000006E69616D 0000000000000000 0000000000000002
0000000000060010 0000000000000001 0000000000000011 0000000000000008 0000000000000008 0000000000000008 0000000000030003 0000000000000005
0000000000000258 0000000000040005 0000000000000001 000000006E69616D 0000000000000000 0000000000040047 0000000000000002 000000000000000B
000000000000001C 0000000000040015 0000000000000003 0000000000000020 0000000000000000 0000000000040017 0000000000000004 0000000000000003
0000000000000003 0000000000040020 0000000000000005 0000000000000001 0000000000000004 0000000000020013 0000000000000006 0000000000030021
0000000000000007 0000000000000006 000000000004003B 0000000000000005 0000000000000002 0000000000000001 0000000000050036 0000000000000006
0000000000000001 0000000000000000 0000000000000007 00000000000200F8 0000000000000008 00000000000100FD 0000000000010038

------------------------------

Test 2 : This one should print errors

Errors :
hlsl.hlsl:14:17: error: use of undeclared identifier 'v1'
    float4 v2 = v1;
                ^
hlsl.hlsl:16:17: error: use of undeclared identifier 'v3'
    float4 v4 = v3;
                ^
```